### PR TITLE
Add track removal option for failed processing

### DIFF
--- a/src/models/db.py
+++ b/src/models/db.py
@@ -108,6 +108,24 @@ def migrate_db():
         except sqlite3.OperationalError as e:
             print(f"Migration error: {e}")
 
+        try:
+            # Add track_failures table if it doesn't exist
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS track_failures (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    track_id TEXT NOT NULL,
+                    error_message TEXT,
+                    failure_count INTEGER DEFAULT 1,
+                    last_attempt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """
+            )
+            db.commit()
+        except sqlite3.OperationalError as e:
+            print(f"Migration error: {e}")
+
 
 def create_invite_key(created_by, key):
     """Create a new invite key."""

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -36,4 +36,13 @@ CREATE TABLE IF NOT EXISTS password_resets (
     used BOOLEAN DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE TABLE IF NOT EXISTS track_failures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id TEXT NOT NULL,
+    error_message TEXT,
+    failure_count INTEGER DEFAULT 1,
+    last_attempt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ); 

--- a/src/static/admin.html
+++ b/src/static/admin.html
@@ -343,6 +343,7 @@
       <div class="tab-container">
         <button class="tab active" onclick="showTab('users')">Users</button>
         <button class="tab" onclick="showTab('usage')">Usage Logs</button>
+        <button class="tab" onclick="showTab('failures')">Failed Tracks</button>
       </div>
 
       <div id="usersTab" class="card">
@@ -454,6 +455,26 @@
             Next
           </button>
         </div>
+      </div>
+
+      <div id="failuresTab" class="card" style="display: none">
+        <h2>Failed Tracks</h2>
+        <p style="color: #6c757d; margin-bottom: 1rem;">
+          Tracks that failed processing multiple times can be removed here.
+        </p>
+        <table id="failedTracksTable">
+          <thead>
+            <tr>
+              <th onclick="sortTable('failedTracksTable', 0)">Track ID ↕</th>
+              <th onclick="sortTable('failedTracksTable', 1)">Error Message ↕</th>
+              <th onclick="sortTable('failedTracksTable', 2)">Failure Count ↕</th>
+              <th onclick="sortTable('failedTracksTable', 3)">Last Attempt ↕</th>
+              <th onclick="sortTable('failedTracksTable', 4)">First Failed ↕</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </div>
     </div>
 
@@ -666,6 +687,8 @@
           tabName === 'users' ? 'block' : 'none'
         document.getElementById('usageTab').style.display =
           tabName === 'usage' ? 'block' : 'none'
+        document.getElementById('failuresTab').style.display =
+          tabName === 'failures' ? 'block' : 'none'
 
         if (tabName === 'users') {
           loadUsers()
@@ -673,6 +696,8 @@
         } else if (tabName === 'usage') {
           loadUsageLogs()
           loadStats()
+        } else if (tabName === 'failures') {
+          loadFailedTracks()
         }
       }
 
@@ -798,6 +823,89 @@
           .catch((err) => {
             console.error('Failed to copy text: ', err)
           })
+      }
+
+      async function loadFailedTracks() {
+        try {
+          const response = await fetch('/admin/failed-tracks', {
+            credentials: 'include',
+          })
+          const tracks = await response.json()
+
+          const tbody = document.querySelector('#failedTracksTable tbody')
+          tbody.innerHTML = tracks
+            .map(
+              (track) => `
+            <tr>
+              <td>${track.track_id}</td>
+              <td style="max-width: 300px; word-wrap: break-word;">${track.error_message || '-'}</td>
+              <td>
+                <span class="status ${
+                  track.failure_count >= 3 ? 'status-pending' : 'status-approved'
+                }" style="background: ${
+                  track.failure_count >= 3 ? '#ffeeba' : '#d4edda'
+                }; color: ${
+                  track.failure_count >= 3 ? '#856404' : '#155724'
+                };">
+                  ${track.failure_count}
+                </span>
+              </td>
+              <td>${new Date(track.last_attempt).toLocaleString()}</td>
+              <td>${new Date(track.created_at).toLocaleString()}</td>
+              <td>
+                <button class="cancel-button" onclick="deleteFailedTrack('${track.track_id}')">
+                  Delete
+                </button>
+              </td>
+            </tr>
+          `
+            )
+            .join('')
+        } catch (error) {
+          console.error('Error loading failed tracks:', error)
+        }
+      }
+
+      async function deleteFailedTrack(trackId) {
+        const confirmMessage =
+          'Are you sure you want to delete this failed track?\n\n' +
+          'This will remove the track from the database and delete all associated files.\n' +
+          'This action cannot be undone.'
+
+        if (!confirm(confirmMessage)) {
+          return
+        }
+
+        try {
+          const response = await fetch(`/admin/failed-tracks/${trackId}`, {
+            method: 'DELETE',
+            credentials: 'include',
+          })
+
+          if (response.ok) {
+            const notification = document.createElement('div')
+            notification.className = 'notification success'
+            notification.textContent = 'Failed track deleted successfully'
+            document.body.appendChild(notification)
+            setTimeout(() => notification.remove(), 3000)
+
+            loadFailedTracks()
+          } else {
+            const data = await response.json()
+            const errorDiv = document.createElement('div')
+            errorDiv.className = 'notification error'
+            errorDiv.textContent = data.error || 'Failed to delete track'
+            document.body.appendChild(errorDiv)
+            setTimeout(() => errorDiv.remove(), 3000)
+          }
+        } catch (error) {
+          console.error('Error deleting failed track:', error)
+          const errorDiv = document.createElement('div')
+          errorDiv.className = 'notification error'
+          errorDiv.textContent = 'Failed to delete track'
+          document.body.appendChild(errorDiv)
+          setTimeout(() => errorDiv.remove(), 3000)
+        }
       }
 
       // Add this to your initialization code


### PR DESCRIPTION
Add a new admin dashboard tab to display and remove tracks that repeatedly fail processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-568986c1-05e6-45d7-bb5a-b85189f5fd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-568986c1-05e6-45d7-bb5a-b85189f5fd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

