### PR TITLE
Add track removal option for failed processing

### DIFF
--- a/FEATURE_TRACK_REMOVAL.md
+++ b/FEATURE_TRACK_REMOVAL.md
@@ -1,0 +1,97 @@
+# Track Processing Failure Management Feature
+
+## Overview
+This feature adds the ability to track failed track processing attempts and provides admins with an option to delete tracks that have failed multiple times.
+
+## Changes Made
+
+### 1. Database Schema (`src/schema.sql`)
+- Added new `processing_failures` table to track failed processing attempts
+  - `track_id`: The ID of the track that failed
+  - `failure_count`: Number of times the track has failed processing
+  - `last_failure`: Timestamp of the most recent failure
+  - `error_message`: The error message from the most recent failure
+
+### 2. Database Migration (`src/models/db.py`)
+- Added migration to create the `processing_failures` table
+- Migration runs automatically on app startup if the table doesn't exist
+
+### 3. Track Processing Logic (`src/routes/track.py`)
+- Updated error handling in `de_add_track()` function to log failures to database
+- Updated error handling in the `/add` route's background thread to track failures
+- Uses SQLite's `ON CONFLICT` clause to increment failure count for repeated failures
+
+### 4. Admin Routes (`src/routes/admin.py`)
+- **Updated `/admin/status/unfinished` endpoint**:
+  - Now includes `failure_count` and `error_message` for each unfinished track
+  - Joins with `processing_failures` table to get failure information
+
+- **New `/admin/track/<track_id>` DELETE endpoint**:
+  - Allows admins to delete failed tracks permanently
+  - Verifies track has a failure record before deletion
+  - Deletes track directory, failure records, and usage logs
+  - Requires admin authentication
+
+- **Updated reprocess error handling**:
+  - Tracks failures when reprocessing fails
+
+### 5. Admin UI (`src/static/status.html`)
+- **Added "Failures" column** to unfinished tracks table
+- **Failure count badge**:
+  - Shows number of failures with color coding (red: ≥3, yellow: ≥2, green: <2)
+  - Displays error message on hover
+- **Delete button**:
+  - Only appears for tracks with 2 or more failures
+  - Shows confirmation dialog before deletion
+  - Provides visual feedback during deletion
+- **Styling**: Added CSS for delete button matching the existing design system
+
+## Usage
+
+### For Administrators
+1. Navigate to **Admin Dashboard → System Status → Unfinished Tracks** tab
+2. View the failure count for each unfinished track
+3. Hover over the failure count badge to see the error message
+4. For tracks with 2+ failures, a **Delete** button will appear
+5. Click **Delete** to permanently remove the track and its files
+6. Confirm the deletion in the dialog
+
+### Automatic Tracking
+- Failures are automatically tracked whenever:
+  - A track fails during initial processing
+  - A track fails during reprocessing
+  - Any processing step (download, split, lyrics) fails
+- The failure count increments each time the same track fails
+- The error message is updated with the most recent error
+
+## Technical Details
+
+### Failure Tracking Query
+```sql
+INSERT INTO processing_failures (track_id, failure_count, error_message)
+VALUES (?, 1, ?)
+ON CONFLICT(track_id) DO UPDATE SET
+    failure_count = failure_count + 1,
+    last_failure = CURRENT_TIMESTAMP,
+    error_message = ?
+```
+
+### Delete Track Logic
+1. Verify track has failure record
+2. Delete track directory (`src/songs/{track_id}/`)
+3. Remove from `processing_failures` table
+4. Remove from `usage_logs` table
+5. Commit transaction
+
+## Security Considerations
+- Delete endpoint requires admin authentication
+- Only tracks with failure records can be deleted (prevents accidental deletion of working tracks)
+- Confirmation dialog prevents accidental deletions
+- All deletions are permanent and cannot be undone
+
+## Future Enhancements
+- Add configurable failure threshold (currently hardcoded at 2)
+- Add bulk delete option for multiple failed tracks
+- Add notification/email alerts for repeated failures
+- Add automatic cleanup after N failures
+- Add failure analytics dashboard

--- a/src/models/db.py
+++ b/src/models/db.py
@@ -129,6 +129,25 @@ def migrate_db():
         except sqlite3.OperationalError as e:
             print(f"Migration error when creating system_status table: {e}")
 
+        try:
+            # Add processing_failures table if it doesn't exist
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS processing_failures (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    track_id TEXT NOT NULL,
+                    failure_count INTEGER DEFAULT 1,
+                    last_failure TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    error_message TEXT,
+                    UNIQUE(track_id)
+                )
+            """
+            )
+            db.commit()
+            print("Added processing_failures table")
+        except sqlite3.OperationalError as e:
+            print(f"Migration error when creating processing_failures table: {e}")
+
 
 def create_invite_key(created_by, key):
     """Create a new invite key."""

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -46,4 +46,13 @@ CREATE TABLE IF NOT EXISTS system_status (
     last_checked TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     checked_by INTEGER,
     FOREIGN KEY (checked_by) REFERENCES users (id)
+);
+
+CREATE TABLE IF NOT EXISTS processing_failures (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    track_id TEXT NOT NULL,
+    failure_count INTEGER DEFAULT 1,
+    last_failure TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    error_message TEXT,
+    UNIQUE(track_id)
 ); 

--- a/src/static/status.html
+++ b/src/static/status.html
@@ -526,6 +526,29 @@
         transform: none;
       }
 
+      .delete-btn {
+        padding: 0.375rem 0.875rem;
+        background: var(--danger);
+        color: white;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .delete-btn:hover {
+        background: #dc2626;
+        transform: translateY(-1px);
+      }
+
+      .delete-btn:disabled {
+        background: var(--text-light);
+        cursor: not-allowed;
+        transform: none;
+      }
+
       .filter-group {
         margin-bottom: 1.5rem;
         background: white;
@@ -1037,6 +1060,7 @@
               <th>Track</th>
               <th>Last Modified</th>
               <th>Completion</th>
+              <th>Failures</th>
               <th>Missing Components</th>
               <th>Actions</th>
             </tr>
@@ -1056,6 +1080,9 @@
                     ? missingItems.join(', ')
                     : 'None'
 
+                const failureCount = song.failure_count || 0
+                const failureBadgeClass = failureCount >= 3 ? 'low' : failureCount >= 2 ? 'medium' : 'high'
+                
                 return `
                 <tr>
                   <td>${song.title || 'Unknown'} - ${
@@ -1065,13 +1092,19 @@
                   <td><span class="completion-badge ${badgeClass}">${
                   song.completion_status || 0
                 }%</span></td>
+                  <td><span class="completion-badge ${failureBadgeClass}" title="${song.error_message || 'No error message'}">${failureCount}x</span></td>
                   <td>${missingText}</td>
                   <td>
                     <button class="reprocess-btn" data-track-id="${
                       song.track_id
-                    }">
+                    }" style="margin-right: 0.5rem;">
                       <i class="fas fa-redo"></i> Reprocess
                     </button>
+                    ${failureCount >= 2 ? `
+                      <button class="delete-btn" data-track-id="${song.track_id}" title="Delete this track permanently">
+                        <i class="fas fa-trash"></i> Delete
+                      </button>
+                    ` : ''}
                   </td>
           </tr>
               `
@@ -1109,6 +1142,41 @@
               showNotification(error.message, true)
               btn.disabled = false
               btn.innerHTML = '<i class="fas fa-redo"></i> Reprocess'
+            }
+          })
+        })
+
+        // Add event listeners to delete buttons
+        document.querySelectorAll('.delete-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const trackId = btn.dataset.trackId
+            
+            if (!confirm(`Are you sure you want to permanently delete track ${trackId}? This action cannot be undone.`)) {
+              return
+            }
+
+            btn.disabled = true
+            btn.innerHTML =
+              '<i class="fas fa-spinner fa-spin"></i> Deleting...'
+
+            try {
+              const response = await fetch(`/admin/track/${trackId}`, {
+                method: 'DELETE',
+                credentials: 'include',
+              })
+
+              const data = await response.json()
+
+              if (response.ok) {
+                showNotification('Track deleted successfully')
+                fetchUnfinishedSongs()
+              } else {
+                throw new Error(data.error || 'Failed to delete track')
+              }
+            } catch (error) {
+              showNotification(error.message, true)
+              btn.disabled = false
+              btn.innerHTML = '<i class="fas fa-trash"></i> Delete'
             }
           })
         })


### PR DESCRIPTION
Add track processing failure tracking and an admin option to delete tracks that fail multiple times.

This feature allows administrators to identify and remove problematic tracks that repeatedly fail processing, preventing them from cluttering the 'Unfinished Tracks' list and consuming resources.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ee798fd-545a-474b-80a7-a0b352161a3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ee798fd-545a-474b-80a7-a0b352161a3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

