### PR TITLE
Fix lyric and progress bar seeking

### DIFF
--- a/src/static/css/styles.css
+++ b/src/static/css/styles.css
@@ -1174,6 +1174,7 @@ body.collapsed .main-container {
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(99, 102, 241, 0.4);
   animation: shimmer 3s ease-in-out infinite;
+  pointer-events: none; /* Allow clicks to pass through to progress-bar */
 }
 
 @keyframes shimmer {


### PR DESCRIPTION
Fix progress bar seeking by adding `pointer-events: none` to the filled progress indicator.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bb6080a-ed83-45e3-89ad-76d9bc270542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bb6080a-ed83-45e3-89ad-76d9bc270542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

