### PR TITLE
Process new song lyrics with error handling

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -203,17 +203,19 @@ def split_long_lyrics_lines(lyrics_id):
         if old_count == new_count + new_offset:
             start_times = [
                 old_words[i]["start"] for i in range(new_offset, new_offset + new_count)
+                if "start" in old_words[i]
             ]
             end_times = [
                 old_words[i]["end"] for i in range(new_offset, new_offset + new_count)
+                if "end" in old_words[i]
             ]
             new_segments.append(
                 {
                     "words": old_words[new_offset : new_offset + new_count],
                     "text": split_lines[new_idx],
                     "speaker": lyrics["segments"][old_idx]["speaker"],
-                    "start": min(start_times),
-                    "end": max(end_times),
+                    "start": min(start_times) if start_times else 0,
+                    "end": max(end_times) if end_times else 0,
                 }
             )
             new_idx += 1
@@ -222,17 +224,19 @@ def split_long_lyrics_lines(lyrics_id):
         elif old_count > new_count + new_offset:
             start_times = [
                 old_words[i]["start"] for i in range(new_offset, new_offset + new_count)
+                if "start" in old_words[i]
             ]
             end_times = [
                 old_words[i]["end"] for i in range(new_offset, new_offset + new_count)
+                if "end" in old_words[i]
             ]
             new_segments.append(
                 {
                     "words": old_words[new_offset : new_offset + new_count],
                     "text": split_lines[new_idx],
                     "speaker": lyrics["segments"][old_idx]["speaker"],
-                    "start": min(start_times),
-                    "end": max(end_times),
+                    "start": min(start_times) if start_times else 0,
+                    "end": max(end_times) if end_times else 0,
                 }
             )
             new_idx += 1


### PR DESCRIPTION
Add safety checks for `start` and `end` keys in `split_long_lyrics_lines` to prevent `KeyError`.

This fixes a `KeyError: 'start'` that occurred during lyrics processing for new songs when some word dictionaries lacked `start` or `end` timestamp keys, ensuring graceful handling and preventing crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a5c8a7b-bd74-4bb9-8c74-6ab0388b5e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a5c8a7b-bd74-4bb9-8c74-6ab0388b5e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

