### PR TITLE
Add song deletion admin page

### DIFF
--- a/ADMIN_SONGS_FEATURE.md
+++ b/ADMIN_SONGS_FEATURE.md
@@ -1,0 +1,157 @@
+# Admin Song Management Feature
+
+## Overview
+Added a comprehensive admin page for managing and deleting songs from the MelodAI library. This feature allows administrators to view all songs in the library with detailed information and delete any song permanently.
+
+## Changes Made
+
+### 1. Backend Routes (`src/routes/admin.py`)
+
+Added three new admin-only routes:
+
+#### `/admin/songs` (GET)
+- Renders the song management page
+- Requires admin authentication
+- Serves the `admin_songs.html` static file
+
+#### `/admin/songs/list` (GET)
+- Returns a JSON list of all songs in the library
+- Requires admin authentication
+- Includes detailed metadata for each song:
+  - Track ID, title, artist, album, duration
+  - Cover image URL
+  - File existence status (song.mp3, vocals.mp3, no_vocals.mp3, lyrics.json)
+  - Total size in MB
+  - Last modified timestamp
+- Songs are sorted alphabetically by title
+
+#### `/admin/songs/<track_id>` (DELETE)
+- Deletes any song from the library (not restricted to failed tracks)
+- Requires admin authentication
+- Removes:
+  - Complete track directory (`src/songs/{track_id}/`)
+  - Any processing failure records
+  - All usage logs for the track
+- Returns success/error JSON response
+
+### 2. Frontend Page (`src/static/admin_songs.html`)
+
+Created a modern, responsive admin interface with:
+
+#### Statistics Dashboard
+- **Total Songs**: Count of all songs in the library
+- **Complete Songs**: Count of songs with all required files
+- **Total Storage**: Total disk space used by all songs
+
+#### Song Management Table
+Features:
+- **Search**: Filter by title, artist, album, or track ID
+- **Filter**: Show all songs, complete only, or incomplete only
+- **Sortable columns**: Click column headers to sort
+- **Song information display**:
+  - Album cover thumbnail
+  - Title and artist
+  - Album name
+  - Duration (formatted as MM:SS)
+  - File size in MB
+  - Status badges (showing missing components)
+  - Track ID
+- **Delete button**: Permanently delete any song with confirmation
+
+#### User Experience
+- Real-time search and filtering
+- Visual feedback for all actions
+- Success/error notifications
+- Responsive design for mobile and desktop
+- Loading states and spinners
+- Empty state messages
+- Confirmation dialogs before deletion
+
+### 3. Navigation Integration (`src/static/admin.html`)
+
+Added a "Songs" tab to the admin dashboard navigation:
+- Positioned between "Usage Logs" and "System Status"
+- Maintains consistent design with other admin tabs
+- Navigates to `/admin/songs` when clicked
+
+## Security Features
+
+1. **Admin Authentication**: All routes require `@admin_required` decorator
+2. **Confirmation Dialogs**: Users must confirm before deleting songs
+3. **Error Handling**: Proper error messages for all failure cases
+4. **Transaction Safety**: Database operations use commits for data integrity
+
+## Usage
+
+### For Administrators
+
+1. Navigate to **Admin Dashboard** → **Songs** tab
+2. View all songs in the library with their status and details
+3. Use the search box to find specific songs
+4. Filter by completion status (all/complete/incomplete)
+5. Click column headers to sort by different attributes
+6. Click **Delete** button on any song to remove it
+7. Confirm the deletion in the dialog
+8. The song and all its files will be permanently removed
+
+### API Endpoints
+
+```bash
+# Get all songs (JSON)
+GET /admin/songs/list
+
+# Delete a song
+DELETE /admin/songs/{track_id}
+```
+
+## Differences from Existing Track Deletion
+
+The existing track deletion feature (`/admin/track/<track_id>`) is:
+- Limited to **failed tracks only** (requires failure record)
+- Accessible only from the System Status page
+- Intended for cleanup of processing failures
+
+The new song deletion feature (`/admin/songs/<track_id>`) is:
+- Available for **any song** in the library
+- Accessible from a dedicated Song Management page
+- Intended for general library management and administration
+
+## Technical Details
+
+### File Structure
+```
+src/
+├── routes/
+│   └── admin.py (3 new routes added)
+└── static/
+    ├── admin.html (navigation updated)
+    └── admin_songs.html (new page)
+```
+
+### Dependencies
+- Uses existing Flask blueprints and decorators
+- Uses existing database connection (`get_db()`)
+- Uses standard Python libraries (json, pathlib, os, shutil)
+- No new external dependencies required
+
+### Data Flow
+1. Frontend loads and calls `/admin/songs/list`
+2. Backend scans `src/songs/` directory
+3. For each song, reads metadata and checks file existence
+4. Returns JSON with all song details
+5. Frontend displays songs in sortable, filterable table
+6. On delete, sends DELETE request to `/admin/songs/<track_id>`
+7. Backend removes files and database records
+8. Frontend updates display and shows notification
+
+## Future Enhancements
+
+Potential improvements:
+- Bulk delete functionality
+- Export song list to CSV
+- Show usage statistics per song
+- Show who added each song
+- Add song details modal/popup
+- Download individual song files
+- Batch operations (delete multiple songs at once)
+- Storage cleanup recommendations

--- a/src/static/admin.html
+++ b/src/static/admin.html
@@ -672,6 +672,10 @@
           <i class="fas fa-chart-line"></i>
           Usage Logs
         </button>
+        <button class="tab" onclick="window.location.href='/admin/songs'">
+          <i class="fas fa-music"></i>
+          Songs
+        </button>
         <button class="tab" onclick="window.location.href='/admin/status'">
           <i class="fas fa-heartbeat"></i>
           System Status

--- a/src/static/admin_songs.html
+++ b/src/static/admin_songs.html
@@ -1,0 +1,827 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Song Management - MelodAI Admin</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    />
+    <link rel="icon" href="/logo.svg" />
+    <style>
+      :root {
+        --primary: #6366f1;
+        --primary-dark: #4f46e5;
+        --secondary: #0ea5e9;
+        --success: #22c55e;
+        --danger: #ef4444;
+        --warning: #f59e0b;
+        --background: #f8fafc;
+        --surface: #ffffff;
+        --text: #1e293b;
+        --text-light: #64748b;
+        --border: #e2e8f0;
+        --hover: #f1f5f9;
+        --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+        --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: var(--background);
+        margin: 0;
+        padding: 0;
+        color: var(--text);
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 2rem;
+        padding: 1.5rem;
+        background: var(--surface);
+        border-radius: 12px;
+        box-shadow: var(--shadow);
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      .header h1 {
+        margin: 0;
+        font-size: 1.875rem;
+        color: var(--primary);
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .header h1 i {
+        font-size: 1.5rem;
+      }
+
+      .btn-container {
+        display: flex;
+        gap: 0.75rem;
+      }
+
+      button,
+      .btn {
+        padding: 0.625rem 1.25rem;
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 0.9rem;
+        font-weight: 500;
+        transition: all 0.2s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        text-decoration: none;
+      }
+
+      .home-btn {
+        background: var(--primary);
+        color: white;
+      }
+
+      .home-btn:hover {
+        background: var(--primary-dark);
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-lg);
+      }
+
+      .admin-btn {
+        background: var(--secondary);
+        color: white;
+      }
+
+      .admin-btn:hover {
+        background: #0284c7;
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-lg);
+      }
+
+      .card {
+        background: var(--surface);
+        padding: 1.5rem;
+        border-radius: 12px;
+        box-shadow: var(--shadow);
+        margin-bottom: 1.5rem;
+      }
+
+      .stats-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.25rem;
+        margin-bottom: 2rem;
+      }
+
+      .stat-card {
+        background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+        padding: 1.5rem;
+        border-radius: 12px;
+        color: white;
+        box-shadow: var(--shadow-lg);
+        transition: transform 0.2s;
+      }
+
+      .stat-card:hover {
+        transform: translateY(-4px);
+      }
+
+      .stat-card i {
+        font-size: 2rem;
+        opacity: 0.8;
+        margin-bottom: 0.75rem;
+      }
+
+      .stat-card h3 {
+        margin: 0 0 0.5rem 0;
+        font-size: 0.9rem;
+        font-weight: 500;
+        opacity: 0.9;
+        color: white;
+      }
+
+      .stat-card p {
+        margin: 0;
+        font-size: 2rem;
+        font-weight: bold;
+        color: white;
+      }
+
+      .stat-card:nth-child(1) {
+        background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+      }
+
+      .stat-card:nth-child(2) {
+        background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+      }
+
+      .stat-card:nth-child(3) {
+        background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
+      }
+
+      .controls {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      .search-box {
+        flex: 1;
+        min-width: 250px;
+      }
+
+      .search-box input {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 2px solid var(--border);
+        border-radius: 8px;
+        font-size: 0.9rem;
+        background: var(--surface);
+        color: var(--text);
+        transition: border-color 0.2s;
+      }
+
+      .search-box input:focus {
+        outline: none;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+      }
+
+      .filter-select {
+        padding: 0.75rem 1rem;
+        border: 2px solid var(--border);
+        border-radius: 8px;
+        font-size: 0.9rem;
+        background: var(--surface);
+        color: var(--text);
+        cursor: pointer;
+        transition: border-color 0.2s;
+      }
+
+      .filter-select:focus {
+        outline: none;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+      }
+
+      .refresh-btn {
+        background: var(--success);
+        color: white;
+        padding: 0.75rem 1rem;
+      }
+
+      .refresh-btn:hover {
+        background: #16a34a;
+        transform: translateY(-1px);
+      }
+
+      .table-wrapper {
+        overflow-x: auto;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: separate;
+        border-spacing: 0;
+        min-width: 800px;
+      }
+
+      th,
+      td {
+        padding: 1rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+      }
+
+      th {
+        background: var(--hover);
+        font-weight: 600;
+        color: var(--text);
+        cursor: pointer;
+        user-select: none;
+        transition: background 0.2s;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+      }
+
+      th:hover {
+        background: var(--border);
+      }
+
+      tbody tr {
+        transition: background 0.2s;
+      }
+
+      tbody tr:hover {
+        background: var(--hover);
+      }
+
+      .song-info {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .song-cover {
+        width: 50px;
+        height: 50px;
+        border-radius: 6px;
+        object-fit: cover;
+        background: var(--border);
+      }
+
+      .song-details h4 {
+        margin: 0 0 0.25rem 0;
+        font-size: 0.95rem;
+        color: var(--text);
+      }
+
+      .song-details p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-light);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 500;
+      }
+
+      .badge-success {
+        background: #d1fae5;
+        color: #065f46;
+      }
+
+      .badge-danger {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+
+      .badge-warning {
+        background: #fef3c7;
+        color: #92400e;
+      }
+
+      .delete-btn {
+        background: var(--danger);
+        color: white;
+        padding: 0.5rem 1rem;
+        font-size: 0.875rem;
+      }
+
+      .delete-btn:hover {
+        background: #dc2626;
+        transform: translateY(-1px);
+      }
+
+      .delete-btn:disabled {
+        background: var(--border);
+        color: var(--text-light);
+        cursor: not-allowed;
+        transform: none;
+      }
+
+      .notification {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        padding: 1rem 1.5rem;
+        border-radius: 12px;
+        animation: slideIn 0.3s ease-out;
+        z-index: 1000;
+        box-shadow: var(--shadow-lg);
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        max-width: 400px;
+      }
+
+      .notification i {
+        font-size: 1.25rem;
+      }
+
+      .notification.success {
+        background: #d1fae5;
+        color: #065f46;
+        border: 2px solid #10b981;
+      }
+
+      .notification.success i {
+        color: #10b981;
+      }
+
+      .notification.error {
+        background: #fee2e2;
+        color: #991b1b;
+        border: 2px solid #ef4444;
+      }
+
+      .notification.error i {
+        color: #ef4444;
+      }
+
+      @keyframes slideIn {
+        from {
+          transform: translateX(100%);
+          opacity: 0;
+        }
+        to {
+          transform: translateX(0);
+          opacity: 1;
+        }
+      }
+
+      .loading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 4rem;
+      }
+
+      .spinner {
+        border: 3px solid var(--border);
+        border-top-color: var(--primary);
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        animation: spin 0.8s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .empty-state {
+        text-align: center;
+        padding: 3rem 1rem;
+        color: var(--text-light);
+      }
+
+      .empty-state i {
+        font-size: 4rem;
+        margin-bottom: 1rem;
+        opacity: 0.3;
+      }
+
+      .empty-state h3 {
+        margin: 0 0 0.5rem 0;
+        color: var(--text);
+      }
+
+      .empty-state p {
+        margin: 0;
+      }
+
+      .sort-asc::after {
+        content: ' ↑';
+        color: var(--primary);
+      }
+
+      .sort-desc::after {
+        content: ' ↓';
+        color: var(--primary);
+      }
+
+      @media (max-width: 768px) {
+        .container {
+          padding: 10px;
+        }
+
+        .header {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .header h1 {
+          font-size: 1.5rem;
+        }
+
+        .btn-container {
+          flex-direction: column;
+        }
+
+        .stats-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .controls {
+          flex-direction: column;
+        }
+
+        .search-box {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>
+          <i class="fas fa-music"></i>
+          Song Management
+        </h1>
+        <div class="btn-container">
+          <a href="/admin" class="admin-btn">
+            <i class="fas fa-shield-alt"></i>
+            Admin Dashboard
+          </a>
+          <a href="/" class="home-btn">
+            <i class="fas fa-home"></i>
+            Home
+          </a>
+        </div>
+      </div>
+
+      <div class="stats-grid">
+        <div class="stat-card">
+          <i class="fas fa-music"></i>
+          <h3>Total Songs</h3>
+          <p id="totalSongs">0</p>
+        </div>
+        <div class="stat-card">
+          <i class="fas fa-check-circle"></i>
+          <h3>Complete Songs</h3>
+          <p id="completeSongs">0</p>
+        </div>
+        <div class="stat-card">
+          <i class="fas fa-hdd"></i>
+          <h3>Total Storage</h3>
+          <p id="totalStorage">0 MB</p>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="controls">
+          <div class="search-box">
+            <input
+              type="text"
+              id="searchInput"
+              placeholder="🔍 Search by title, artist, or album..."
+              onkeyup="filterSongs()"
+            />
+          </div>
+          <select id="filterSelect" class="filter-select" onchange="filterSongs()">
+            <option value="all">All Songs</option>
+            <option value="complete">Complete Only</option>
+            <option value="incomplete">Incomplete Only</option>
+          </select>
+          <button class="refresh-btn" onclick="loadSongs()">
+            <i class="fas fa-sync-alt" id="refreshIcon"></i>
+            Refresh
+          </button>
+        </div>
+
+        <div class="table-wrapper">
+          <table id="songsTable">
+            <thead>
+              <tr>
+                <th onclick="sortTable(0)">Song</th>
+                <th onclick="sortTable(1)">Album</th>
+                <th onclick="sortTable(2)">Duration</th>
+                <th onclick="sortTable(3)">Size</th>
+                <th onclick="sortTable(4)">Status</th>
+                <th onclick="sortTable(5)">Track ID</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="songsTableBody">
+              <tr>
+                <td colspan="7">
+                  <div class="loading">
+                    <div class="spinner"></div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      let allSongs = []
+      let currentSort = {
+        column: null,
+        direction: 'asc',
+      }
+
+      async function loadSongs() {
+        const refreshIcon = document.getElementById('refreshIcon')
+        refreshIcon.style.animation = 'spin 0.8s linear infinite'
+
+        try {
+          const response = await fetch('/admin/songs/list', {
+            credentials: 'include',
+          })
+          const data = await response.json()
+          allSongs = data.songs
+
+          updateStats()
+          displaySongs(allSongs)
+        } catch (error) {
+          console.error('Error loading songs:', error)
+          document.getElementById('songsTableBody').innerHTML = `
+            <tr>
+              <td colspan="7">
+                <div class="empty-state">
+                  <i class="fas fa-exclamation-triangle"></i>
+                  <h3>Error loading songs</h3>
+                  <p>${error.message}</p>
+                </div>
+              </td>
+            </tr>
+          `
+        } finally {
+          refreshIcon.style.animation = ''
+        }
+      }
+
+      function updateStats() {
+        const totalSongs = allSongs.length
+        const completeSongs = allSongs.filter(
+          (s) => s.has_song && s.has_vocals && s.has_no_vocals && s.has_lyrics
+        ).length
+        const totalStorage = allSongs.reduce((sum, s) => sum + s.size_mb, 0)
+
+        document.getElementById('totalSongs').textContent = totalSongs
+        document.getElementById('completeSongs').textContent = completeSongs
+        document.getElementById('totalStorage').textContent = totalStorage.toFixed(2) + ' MB'
+      }
+
+      function displaySongs(songs) {
+        const tbody = document.getElementById('songsTableBody')
+
+        if (songs.length === 0) {
+          tbody.innerHTML = `
+            <tr>
+              <td colspan="7">
+                <div class="empty-state">
+                  <i class="fas fa-music"></i>
+                  <h3>No songs found</h3>
+                  <p>No songs match your search criteria.</p>
+                </div>
+              </td>
+            </tr>
+          `
+          return
+        }
+
+        tbody.innerHTML = songs
+          .map((song) => {
+            const isComplete =
+              song.has_song && song.has_vocals && song.has_no_vocals && song.has_lyrics
+            const coverUrl = song.cover
+              ? `https://e-cdns-images.dzcdn.net/images/cover/${song.cover}/250x250-000000-80-0-0.jpg`
+              : ''
+
+            const statusBadges = []
+            if (!song.has_song) statusBadges.push('<span class="badge badge-danger"><i class="fas fa-times"></i> Song</span>')
+            if (!song.has_vocals) statusBadges.push('<span class="badge badge-danger"><i class="fas fa-times"></i> Vocals</span>')
+            if (!song.has_no_vocals) statusBadges.push('<span class="badge badge-danger"><i class="fas fa-times"></i> Instrumental</span>')
+            if (!song.has_lyrics) statusBadges.push('<span class="badge badge-danger"><i class="fas fa-times"></i> Lyrics</span>')
+
+            const statusDisplay = isComplete
+              ? '<span class="badge badge-success"><i class="fas fa-check"></i> Complete</span>'
+              : statusBadges.join(' ')
+
+            return `
+              <tr>
+                <td>
+                  <div class="song-info">
+                    ${coverUrl ? `<img src="${coverUrl}" alt="${song.title}" class="song-cover" />` : '<div class="song-cover"></div>'}
+                    <div class="song-details">
+                      <h4>${song.title}</h4>
+                      <p>${song.artist}</p>
+                    </div>
+                  </div>
+                </td>
+                <td>${song.album}</td>
+                <td>${formatDuration(song.duration)}</td>
+                <td>${song.size_mb} MB</td>
+                <td>${statusDisplay}</td>
+                <td><code>${song.track_id}</code></td>
+                <td>
+                  <button 
+                    class="delete-btn" 
+                    onclick="deleteSong('${song.track_id}')"
+                    title="Delete this song permanently"
+                  >
+                    <i class="fas fa-trash"></i> Delete
+                  </button>
+                </td>
+              </tr>
+            `
+          })
+          .join('')
+      }
+
+      function formatDuration(seconds) {
+        const mins = Math.floor(seconds / 60)
+        const secs = seconds % 60
+        return `${mins}:${secs.toString().padStart(2, '0')}`
+      }
+
+      function filterSongs() {
+        const searchTerm = document.getElementById('searchInput').value.toLowerCase()
+        const filter = document.getElementById('filterSelect').value
+
+        let filtered = allSongs
+
+        // Apply search filter
+        if (searchTerm) {
+          filtered = filtered.filter(
+            (s) =>
+              s.title.toLowerCase().includes(searchTerm) ||
+              s.artist.toLowerCase().includes(searchTerm) ||
+              s.album.toLowerCase().includes(searchTerm) ||
+              s.track_id.includes(searchTerm)
+          )
+        }
+
+        // Apply status filter
+        if (filter === 'complete') {
+          filtered = filtered.filter(
+            (s) => s.has_song && s.has_vocals && s.has_no_vocals && s.has_lyrics
+          )
+        } else if (filter === 'incomplete') {
+          filtered = filtered.filter(
+            (s) => !s.has_song || !s.has_vocals || !s.has_no_vocals || !s.has_lyrics
+          )
+        }
+
+        displaySongs(filtered)
+      }
+
+      function sortTable(column) {
+        const headers = document.querySelectorAll('#songsTable th')
+
+        if (currentSort.column === column) {
+          currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc'
+        } else {
+          currentSort.column = column
+          currentSort.direction = 'asc'
+        }
+
+        // Remove sort classes
+        headers.forEach((h) => h.classList.remove('sort-asc', 'sort-desc'))
+        headers[column].classList.add(`sort-${currentSort.direction}`)
+
+        // Sort the songs
+        const sortedSongs = [...allSongs].sort((a, b) => {
+          let aVal, bVal
+
+          switch (column) {
+            case 0: // Song
+              aVal = a.title.toLowerCase()
+              bVal = b.title.toLowerCase()
+              break
+            case 1: // Album
+              aVal = a.album.toLowerCase()
+              bVal = b.album.toLowerCase()
+              break
+            case 2: // Duration
+              aVal = a.duration
+              bVal = b.duration
+              break
+            case 3: // Size
+              aVal = a.size_mb
+              bVal = b.size_mb
+              break
+            case 4: // Status
+              aVal = (a.has_song && a.has_vocals && a.has_no_vocals && a.has_lyrics) ? 1 : 0
+              bVal = (b.has_song && b.has_vocals && b.has_no_vocals && b.has_lyrics) ? 1 : 0
+              break
+            case 5: // Track ID
+              aVal = a.track_id
+              bVal = b.track_id
+              break
+            default:
+              return 0
+          }
+
+          if (aVal < bVal) return currentSort.direction === 'asc' ? -1 : 1
+          if (aVal > bVal) return currentSort.direction === 'asc' ? 1 : -1
+          return 0
+        })
+
+        allSongs = sortedSongs
+        filterSongs()
+      }
+
+      async function deleteSong(trackId) {
+        if (
+          !confirm(
+            `Are you sure you want to permanently delete this song?\n\nTrack ID: ${trackId}\n\nThis action cannot be undone and will delete all associated files.`
+          )
+        ) {
+          return
+        }
+
+        try {
+          const response = await fetch(`/admin/songs/${trackId}`, {
+            method: 'DELETE',
+            credentials: 'include',
+          })
+
+          const data = await response.json()
+
+          if (response.ok) {
+            showNotification('Song deleted successfully!', 'success')
+            // Remove from local array
+            allSongs = allSongs.filter((s) => s.track_id !== trackId)
+            updateStats()
+            filterSongs()
+          } else {
+            throw new Error(data.error || 'Failed to delete song')
+          }
+        } catch (error) {
+          console.error('Error deleting song:', error)
+          showNotification(error.message, 'error')
+        }
+      }
+
+      function showNotification(message, type) {
+        const notification = document.createElement('div')
+        notification.className = `notification ${type}`
+        notification.innerHTML = `
+          <i class="fas fa-${type === 'success' ? 'check-circle' : 'exclamation-circle'}"></i>
+          ${message}
+        `
+        document.body.appendChild(notification)
+        setTimeout(() => notification.remove(), 3000)
+      }
+
+      // Load songs on page load
+      document.addEventListener('DOMContentLoaded', loadSongs)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Add a dedicated admin page to manage and delete any song from the library, expanding on the existing failed-track-only deletion.

The existing track deletion feature was limited to only failed tracks. This PR introduces a comprehensive admin page (`/admin/songs`) where administrators can view, search, filter, and permanently delete any song from the library, along with all its associated files and database records.

---
<a href="https://cursor.com/background-agent?bcId=bc-654385bc-4b56-4fe1-81c9-8b528cfdc5f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-654385bc-4b56-4fe1-81c9-8b528cfdc5f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

