### PR TITLE
Separate download and play logging

### DIFF
--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -178,6 +178,9 @@ def get_usage_stats():
         "total_downloads": db.execute(
             "SELECT COUNT(*) FROM usage_logs WHERE action = 'download'"
         ).fetchone()[0],
+        "total_plays": db.execute(
+            "SELECT COUNT(*) FROM usage_logs WHERE action = 'play'"
+        ).fetchone()[0],
         "total_searches": db.execute(
             "SELECT COUNT(*) FROM usage_logs WHERE action = 'search'"
         ).fetchone()[0],
@@ -430,7 +433,7 @@ def reprocess_track():
                     f"Started reprocessing track {track_id} manually",
                     user_id,
                 )
-                de_add_track(track_id)
+                de_add_track(track_id, user_id)
                 # Status updates are stored in database instead of socket emit
                 update_queue_item_status(track_id, "complete", 100)
             except Exception as e:

--- a/src/static/admin.html
+++ b/src/static/admin.html
@@ -115,6 +115,11 @@
             <h3>Total Downloads</h3>
             <p id="totalDownloads">-</p>
           </div>
+            <div class="stat-card">
+              <i class="fas fa-play"></i>
+              <h3>Total Plays</h3>
+              <p id="totalPlays">-</p>
+            </div>
           <div class="stat-card">
             <i class="fas fa-search"></i>
             <h3>Total Searches</h3>
@@ -144,6 +149,7 @@
             <select id="actionFilter" onchange="loadUsageLogs(1)">
               <option value="">All actions</option>
               <option value="download">Download</option>
+              <option value="play">Play</option>
               <option value="search">Search</option>
               <option value="random_play">Random Play</option>
             </select>
@@ -523,6 +529,8 @@
                         ? 'download'
                         : log.action === 'search'
                         ? 'search'
+                        : log.action === 'play'
+                        ? 'play'
                         : 'random'
                     }"></i> ${log.action}</td>
                     <td><code>${log.track_id}</code></td>
@@ -730,6 +738,8 @@
           document.getElementById('totalUsers').textContent = stats.total_users
           document.getElementById('totalDownloads').textContent =
             stats.total_downloads
+          document.getElementById('totalPlays').textContent =
+            stats.total_plays
           document.getElementById('totalSearches').textContent =
             stats.total_searches
           document.getElementById('totalRandomPlays').textContent =

--- a/src/static/js/player.js
+++ b/src/static/js/player.js
@@ -27,6 +27,7 @@ class KaraokePlayer {
     this.currentSongIndex = -1
     this.hasUserInteracted = false
     this.pollingInterval = null
+    this.playedTrackIds = new Set()
 
     // Add event listener for first interaction
     document.addEventListener(
@@ -824,6 +825,18 @@ class KaraokePlayer {
           document
             .querySelector('#playButton i')
             .classList.replace('fa-play', 'fa-pause')
+
+          // Log first play for this track (once per track)
+          const currentSong = this.songQueue[this.currentSongIndex]
+          if (currentSong && !this.playedTrackIds.has(currentSong.id)) {
+            fetch('/play', {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ track_id: currentSong.id }),
+            }).catch((err) => console.error('Error logging play:', err))
+            this.playedTrackIds.add(currentSong.id)
+          }
         })
         .catch((error) => {
           console.error('Error playing audio:', error)


### PR DESCRIPTION
Separate download and play logging to accurately reflect user actions and improve analytics.

Previously, a "download" was logged every time a song was requested, regardless of whether a new file was actually downloaded. This change ensures "download" is logged only upon a successful new file acquisition, and introduces a distinct "play" log for when a song begins playback.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd56166b-90c9-4580-b351-8514e6ae7344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd56166b-90c9-4580-b351-8514e6ae7344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

